### PR TITLE
create application-db user from master password

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 GITHUB_ORG := $(shell echo ${REPOSITORY} | cut -d "/" -f 2)
 GITHUB_REPO := $(shell echo ${REPOSITORY} | cut -d "/" -f 3)
 
-run:
+run: create-db-user
 	@echo "Set CIRCLECI environment variables\n"
 	export AWS_ACCESS_KEY_ID=$(shell aws secretsmanager get-secret-value --region ${region} --secret-id=ci-user-aws-keys${randomSeed} | jq -r '.SecretString'| jq -r .access_key_id)
 	export AWS_SECRET_ACCESS_KEY=$(shell aws secretsmanager get-secret-value --region ${region} --secret-id=ci-user-aws-keys${randomSeed} | jq -r '.SecretString'| jq -r .secret_key)
@@ -17,6 +17,12 @@ run:
 	curl -X POST https://circleci.com/api/v1.1/project/github/${GITHUB_ORG}/${GITHUB_REPO}/follow?circle-token=${CIRCLECI_API_KEY}
 	@echo "\nDone"
 
+create-db-user:
+	export REGION=${region}; \
+	export SEED=${randomSeed}; \
+	export PROJECT_NAME=${PROJECT_NAME}; \
+	export ENVIRONMENT=${ENVIRONMENT}; \
+	sh ./db-ops/create-db-user.sh
 
 summary:
 	@echo "zero-deployable-backend:"

--- a/db-ops/create-db-user.sh
+++ b/db-ops/create-db-user.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+# docker image with postgres client only
+DOCKER_IMAGE_TAG=governmentpaas/psql:latest
+
+DB_ENDPOINT=$(aws rds describe-db-instances --region=$REGION --query "DBInstances[?DBName=='$PROJECT_NAME'].Endpoint.Address" | jq -r '.[0]')
+SECRET_ID=$(aws secretsmanager list-secrets --region $REGION  --query "SecretList[?Name=='$PROJECT_NAME-$ENVIRONMENT-rds-$SEED'].Name" | jq -r ".[0]")
+# RDS MASTER
+MASTER_RDS_USERNAME=master_user
+SECRET_PASSWORD=$(aws secretsmanager get-secret-value --region=$REGION --secret-id=$SECRET_ID | jq -r ".SecretString")
+# APPLICATION DB ADMIN
+DB_APP_USERNAME=$PROJECT_NAME
+DB_APP_PASSWORD=$(LC_ALL=C tr -dc 'A-Za-z0-9' < /dev/urandom | base64 | head -c 16)
+
+# Fill in env-vars to db user creation manifest
+eval "echo \"$(cat ./db-ops/job-create-db.yml.tpl)\"" > ./k8s-job-create-db.yml
+# the manifest creates 4 things
+# 1. Namespace: db-ops 
+# 2. Secret in db-ops: db-create-users (with master password, and a .sql file
+# 3. Job in db-ops: db-create-users (runs the .sql file against the RDS given master_password from env)
+# 4. Secret in Application namespace with DB_USERNAME / DB_PASSWORD 
+kubectl create -f ./k8s-job-create-db.yml
+
+# Deleting the entire db-ops namespace, leaving ONLY application-namespace's secret behind
+kubectl wait --for=condition=complete --timeout=10s job db-create-users
+if [ $? -eq 0 ]
+then 
+  kubectl delete namespace db-ops
+else 
+  echo "Failed to create application database user, please see 'kubectl logs -n db-ops -l job-name=db-create-users'"
+fi

--- a/db-ops/job-create-db.yml.tpl
+++ b/db-ops/job-create-db.yml.tpl
@@ -1,0 +1,59 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: db-ops
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: db-create-users
+  namespace: db-ops
+type: Opaque
+stringData: 
+  create-user.sql: |
+    create user $DB_APP_USERNAME with encrypted password '$DB_APP_PASSWORD';
+    grant all privileges on database $PROJECT_NAME to $DB_APP_USERNAME;
+  RDS_MASTER_PASSWORD: $SECRET_PASSWORD
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: $PROJECT_NAME
+  namespace: $PROJECT_NAME
+type: Opaque
+stringData: 
+  DB_USERNAME: $DB_APP_USERNAME
+  DB_PASSWORD: $DB_APP_PASSWORD
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: db-create-users
+  namespace: db-ops
+spec:
+  template:
+    spec:
+      containers:
+      - name: create-rds-user
+        image: $DOCKER_IMAGE_TAG
+        command: 
+        - sh
+        args: 
+        - '-c' 
+        - psql -U$MASTER_RDS_USERNAME -h $DB_ENDPOINT $PROJECT_NAME -a -f/db-ops/create-user.sql > /dev/null
+        env:
+        - name: PGPASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: db-create-users
+              key: RDS_MASTER_PASSWORD
+        volumeMounts:
+        - mountPath: /db-ops/create-user.sql
+          name: db-create-users
+          subPath: create-user.sql
+      volumes:
+        - name: db-create-users
+          secret:
+            secretName: db-create-users
+      restartPolicy: Never
+  backoffLimit: 1


### PR DESCRIPTION
The backend service expects a sercet with `DB_PASSWORD` and `DB_USERNAME` 
Currently we provision an RDS with a master password, and its a horrible idea for application to use master password to connect to db, this PR creates an extra step during `apply` to create a application specific user in the db and a k8s-secret 


- the manifest creates 4 things
    - Namespace: db-ops 
    - Secret in db-ops: db-create-users (with master password, and a .sql file
    - Job in db-ops: db-create-users (runs the .sql file against the RDS given master_password from env)
    - Secret in Application namespace with DB_USERNAME / DB_PASSWORD 
- then it deletes the `db-ops` namespace leaving only the  `Secret in Application namespace` behind