### PR TITLE
fix wrong secret key for database

### DIFF
--- a/db-ops/job-create-db.yml.tpl
+++ b/db-ops/job-create-db.yml.tpl
@@ -22,8 +22,8 @@ metadata:
   namespace: $PROJECT_NAME
 type: Opaque
 stringData: 
-  DB_USERNAME: $DB_APP_USERNAME
-  DB_PASSWORD: $DB_APP_PASSWORD
+  DATABASE_USERNAME: $DB_APP_USERNAME
+  DATABASE_PASSWORD: $DB_APP_PASSWORD
 ---
 apiVersion: batch/v1
 kind: Job


### PR DESCRIPTION
https://github.com/commitdev/zero-deployable-backend/blob/master/templates/kubernetes/base/deployment.yml#L49-L58

I thought it was DB_USERNAME/DB_PASSWORD, its actually DATABASE_USERNAME/DATABASE_PASSWORD