### PR TITLE
Create app namespace during db-user creation

### DIFF
--- a/db-ops/job-create-db.yml.tpl
+++ b/db-ops/job-create-db.yml.tpl
@@ -16,6 +16,11 @@ stringData:
   RDS_MASTER_PASSWORD: $SECRET_PASSWORD
 ---
 apiVersion: v1
+kind: Namespace
+metadata:
+  name: $PROJECT_NAME
+---
+apiVersion: v1
 kind: Secret
 metadata:
   name: $PROJECT_NAME


### PR DESCRIPTION
at the point where the script is ran, there actually isn't the application namespace yet
it is created during the circleci running kustomize