### PR TITLE
support mysql as database option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ create-db-user:
 	export SEED=${randomSeed}; \
 	export PROJECT_NAME=${PROJECT_NAME}; \
 	export ENVIRONMENT=${ENVIRONMENT}; \
+	export DATABASE=${database}; \
 	sh ./db-ops/create-db-user.sh
 
 summary:

--- a/db-ops/create-db-user.sh
+++ b/db-ops/create-db-user.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-# docker image with postgres client only
-DOCKER_IMAGE_TAG=governmentpaas/psql:latest
-
+# docker image with postgres.mysql client only
+# TODO: use image from commit org
+DOCKER_IMAGE_TAG=davidcheung/database-clients:0.1
 DB_ENDPOINT=database.$PROJECT_NAME
 DB_NAME=$(aws rds describe-db-instances --region=$REGION --query "DBInstances[?DBInstanceIdentifier=='$PROJECT_NAME-$ENVIRONMENT'].DBName" | jq -r '.[0]')
 SECRET_ID=$(aws secretsmanager list-secrets --region $REGION  --query "SecretList[?Name=='$PROJECT_NAME-$ENVIRONMENT-rds-$SEED'].Name" | jq -r ".[0]")
@@ -14,7 +14,7 @@ DB_APP_USERNAME=$DB_NAME
 DB_APP_PASSWORD=$(LC_ALL=C tr -dc 'A-Za-z0-9' < /dev/urandom | base64 | head -c 16)
 
 # Fill in env-vars to db user creation manifest
-eval "echo \"$(cat ./db-ops/job-create-db.yml.tpl)\"" > ./k8s-job-create-db.yml
+eval "echo \"$(cat ./db-ops/job-create-db-$DATABASE.yml.tpl)\"" > ./k8s-job-create-db.yml
 # the manifest creates 4 things
 # 1. Namespace: db-ops 
 # 2. Secret in db-ops: db-create-users (with master password, and a .sql file

--- a/db-ops/job-create-db-mysql.yml.tpl
+++ b/db-ops/job-create-db-mysql.yml.tpl
@@ -1,0 +1,106 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: db-ops
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: db-create-users
+  namespace: db-ops
+type: Opaque
+stringData: 
+  create-user.sql: |
+    CREATE USER '$DB_APP_USERNAME' IDENTIFIED BY '$DB_APP_PASSWORD';
+    GRANT ALL PRIVILEGES ON $DB_NAME.* TO '$DB_APP_USERNAME';
+  RDS_MASTER_PASSWORD: $SECRET_PASSWORD
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: $PROJECT_NAME
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: $PROJECT_NAME
+  namespace: $PROJECT_NAME
+type: Opaque
+stringData: 
+  DATABASE_USERNAME: $DB_APP_USERNAME
+  DATABASE_PASSWORD: $DB_APP_PASSWORD
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: db-create-users
+  namespace: db-ops
+spec:
+  template:
+    spec:
+      containers:
+      - name: create-rds-user
+        image: $DOCKER_IMAGE_TAG
+        command: 
+        - sh
+        args: 
+        - '-c' 
+        - mysql -u$MASTER_RDS_USERNAME -h $DB_ENDPOINT $DB_NAME < /db-ops/create-user.sql
+        env:
+        - name: DB_ENDPOINT
+          value: $DB_ENDPOINT
+        - name: DB_NAME
+          value: $DB_NAME
+        - name: MYSQL_PWD
+          valueFrom:
+            secretKeyRef:
+              name: db-create-users
+              key: RDS_MASTER_PASSWORD
+        volumeMounts:
+        - mountPath: /db-ops/create-user.sql
+          name: db-create-users
+          subPath: create-user.sql
+      volumes:
+        - name: db-create-users
+          secret:
+            secretName: db-create-users
+      restartPolicy: Never
+  backoffLimit: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: db-pod
+  namespace: $PROJECT_NAME
+spec:
+# this is purposely left at 0 so it can be enabled for troubleshooting purposes
+  replicas: 0
+  selector:
+    matchLabels:
+      app: db-pod
+  template:
+    metadata:
+      labels:
+        app: db-pod
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - command:
+        - sh
+        args: 
+        - "-c"
+        # long running task so the pod doesn't exit with 0
+        - tail -f /dev/null
+        image: $DOCKER_IMAGE_TAG
+        imagePullPolicy: Always
+        name: db-pod
+        env:
+        - name: DB_ENDPOINT
+          value: $DB_ENDPOINT
+        - name: DB_NAME
+          value: $DB_NAME
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: $PROJECT_NAME
+              key: DATABASE_PASSWORD

--- a/db-ops/job-create-db-postgres.yml.tpl
+++ b/db-ops/job-create-db-postgres.yml.tpl
@@ -82,16 +82,21 @@ spec:
       automountServiceAccountToken: false
       containers:
       - command:
-        - tail
-        - -f
-        - /dev/null
-        image: governmentpaas/psql:latest
+        - sh
+        args: 
+        - "-c"
+        # long running task so the pod doesn't exit with 0
+        - tail -f /dev/null
+        image: $DOCKER_IMAGE_TAG
         imagePullPolicy: Always
         name: db-pod
         env:
-        - name: PGPASSWORD
+        - name: DB_ENDPOINT
+          value: $DB_ENDPOINT
+        - name: DB_NAME
+          value: $DB_NAME
+        - name: DB_PASSWORD
           valueFrom:
             secretKeyRef:
               name: $PROJECT_NAME
               key: DATABASE_PASSWORD
-

--- a/zero-module.yml
+++ b/zero-module.yml
@@ -65,6 +65,11 @@ parameters:
       type: regex
       value: '^([a-z0-9]+(-[a-z0-9]+)*\.)$'
       errorMessage: Invalid subdomain (cannot contain special chars & must end with a '.')
+  - field: database
+    label: Database engine to use (postgres)
+    options:
+      - "postgres"
+      - "mysql"
   - field: accountId
     label: AWS Account ID
     execute: aws sts get-caller-identity --query "Account" | tr -d '"'


### PR DESCRIPTION
**Things that gets created** 
- [db-ops namespace]
  - secret
  - job that creates the application user
- [application namespace]
  - secret with application namespace
  - utility pod with 0 replicas

**Things left behind** 
- [application namespace]
  - secret with application namespace
  - utility pod with 0 replicas

^ kind of feature parity of what we had except supporting both DB


**Things I'm still exploring how to do properly:**
- alias in the pod to connect to the database (since we already know the engine/db name/password), so users can just `kubectl exec -it <podname> sh` into the pod and type eg `db-connect` and be inside the database
- proxy (is nginx the best option?)
- how to store the password without it exposing to logs
  - I'm running eval as a templating tool from shell script, maybe use envsubst instead?
  - writing password to a file and cat the password to login something like `mysql -p$(cat /db-ops/rds-password)` 
- 