### PR TITLE
Mitigate ECR update tag errors out when no change

### DIFF
--- a/templates/.circleci/config.yml
+++ b/templates/.circleci/config.yml
@@ -269,7 +269,7 @@ jobs:
               exit 1
             fi
             MANIFEST=$(aws ecr batch-get-image --region << parameters.region >> --repository-name << parameters.repo >> --image-ids imageTag=latest --query 'images[].imageManifest' --output text)
-            aws ecr put-image --region << parameters.region >> --repository-name << parameters.repo >> --image-tag last-deployed --image-manifest "$MANIFEST"
+            aws ecr put-image --region << parameters.region >> --repository-name << parameters.repo >> --image-tag last-deployed --image-manifest "$MANIFEST" || echo "Image Tag already updated"
 
 workflows:
     version: 2

--- a/templates/.github/actions/deploy/action.yml
+++ b/templates/.github/actions/deploy/action.yml
@@ -46,4 +46,4 @@ runs:
       fi
       # Update the last-deployed tag to be used in dev environments
       MANIFEST=$(aws ecr batch-get-image --region ${{ inputs.region }} --repository-name ${{ inputs.repository-name }} --image-ids imageTag=${{ inputs.image-tag }} --query 'images[].imageManifest' --output text)
-      aws ecr put-image --region ${{ inputs.region }} --repository-name ${{ inputs.repository-name }} --image-tag last-deployed --image-manifest "$MANIFEST"
+      aws ecr put-image --region ${{ inputs.region }} --repository-name ${{ inputs.repository-name }} --image-tag last-deployed --image-manifest "$MANIFEST" || echo "Image Tag already updated"


### PR DESCRIPTION
in dev-env we use last-deployed tag to spin up the deployment, so when we deploy we tag the deployed image, but if we tag it twice it errors out.